### PR TITLE
for_each_field_impl: use fold expressions if possible

### DIFF
--- a/include/boost/pfr/detail/for_each_field_impl.hpp
+++ b/include/boost/pfr/detail/for_each_field_impl.hpp
@@ -29,7 +29,7 @@ void for_each_field_impl_apply(T&& v, F&& f, I /*i*/, int) {
     std::forward<F>(f)(std::forward<T>(v));
 }
 
-#if __cpp_fold_expressions < 201603
+#if !defined(__cpp_fold_expressions) || __cpp_fold_expressions < 201603
 template <class T, class F, std::size_t... I>
 void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::false_type /*move_values*/) {
      const int v[] = {0, (

--- a/include/boost/pfr/detail/for_each_field_impl.hpp
+++ b/include/boost/pfr/detail/for_each_field_impl.hpp
@@ -29,6 +29,7 @@ void for_each_field_impl_apply(T&& v, F&& f, I /*i*/, int) {
     std::forward<F>(f)(std::forward<T>(v));
 }
 
+#if __cpp_fold_expressions < 201603
 template <class T, class F, std::size_t... I>
 void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::false_type /*move_values*/) {
      const int v[] = {0, (
@@ -47,6 +48,17 @@ void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::true_type 
      )...};
      (void)v;
 }
+#else
+template <class T, class F, std::size_t... I>
+void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::false_type /*move_values*/) {
+     (detail::for_each_field_impl_apply(sequence_tuple::get<I>(t), std::forward<F>(f), size_t_<I>{}, 1L), ...);
+}
+
+template <class T, class F, std::size_t... I>
+void for_each_field_impl(T& t, F&& f, std::index_sequence<I...>, std::true_type /*move_values*/) {
+     (detail::for_each_field_impl_apply(sequence_tuple::get<I>(std::move(t)), std::forward<F>(f), size_t_<I>{}, 1L), ...);
+}
+#endif
 
 }}} // namespace boost::pfr::detail
 


### PR DESCRIPTION
This makes empty structs work with MSVC in that case.