### PR TITLE
Add boost::pfr::detail::guaranteed_nonreflectable tag

### DIFF
--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -26,6 +26,9 @@
 
 namespace boost { namespace pfr { namespace detail {
 
+///////////////////// Tag that can be used to say that this type is not reflectable(for internal use only)
+struct guaranteed_nonreflectable {};
+
 ///////////////////// Structure that can be converted to reference to anything
 struct ubiq_lref_constructor {
     std::size_t ignore;
@@ -262,6 +265,11 @@ constexpr std::size_t fields_count() noexcept {
     static_assert(
         !std::is_reference<type>::value,
         "====================> Boost.PFR: Attempt to get fields count on a reference. This is not allowed because that could hide an issue and different library users expect different behavior in that case."
+    );
+
+    static_assert(
+        !std::is_base_of<guaranteed_nonreflectable, type>::value,
+        "====================> Boost.PFR: Type is non-reflectable"
     );
 
 #if !BOOST_PFR_HAS_GUARANTEED_COPY_ELISION

--- a/test/compile-fail/guaranteed_nonreflectable.cpp
+++ b/test/compile-fail/guaranteed_nonreflectable.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2022 Denis Mikhailov
+
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/pfr/core.hpp>
+
+struct A : boost::pfr::detail::guaranteed_nonreflectable
+{};
+
+int main() {
+    (void)boost::pfr::tuple_size<A>::value; // Must be a compile time error
+}
+


### PR DESCRIPTION
It's for library's developers, to help compile-time debugging.
This PR used in https://github.com/boostorg/pfr/issues/100