### PR TITLE
Add 'is_view' dummy trait

### DIFF
--- a/include/boost/pfr/traits.hpp
+++ b/include/boost/pfr/traits.hpp
@@ -51,12 +51,26 @@ struct is_reflectable<const volatile T, WhatFor> : boost::pfr::is_reflectable<T,
 /// Specialize is_reflectable if you are disagree with is_implicitly_reflectable's default decision.
 template<class T, class WhatFor>
 using is_implicitly_reflectable = std::integral_constant< bool, boost::pfr::detail::possible_reflectable<T, WhatFor>(1L) >;
+#endif
 
+/// Checks the input type for having of reference semantic.
+/// Returns true if T can be passed by value as cheap as any reference.
+/// \note The behavior of a program that adds specializations for is_view is undefined.
+///
+template<class T>
+struct is_view : std::integral_constant<bool, false> {};
+
+#if BOOST_PFR_ENABLE_IMPLICIT_REFLECTION
 /// Checks the input type for the potential to be reflected.
 /// Specialize is_reflectable if you are disagree with is_implicitly_reflectable_v's default decision.
 template<class T, class WhatFor>
 constexpr bool is_implicitly_reflectable_v = is_implicitly_reflectable<T, WhatFor>::value;
 #endif
+
+/// Checks the input type for having of reference semantic.
+/// Equals true for T that can be passed by value as cheap as any reference.
+template<class T>
+constexpr bool is_view_v = is_view<T>::value;
 
 }} // namespace boost::pfr
 

--- a/include/boost/pfr/traits_fwd.hpp
+++ b/include/boost/pfr/traits_fwd.hpp
@@ -14,6 +14,9 @@ namespace boost { namespace pfr {
 template<class T, class WhatFor>
 struct is_reflectable;
 
+template<class T>
+struct is_view;
+
 }} // namespace boost::pfr
 
 #endif // BOOST_PFR_DETAIL_TRAITS_FWD_HPP

--- a/test/run/is_view.cpp
+++ b/test/run/is_view.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 Denis Mikhailov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/pfr/traits.hpp>
+
+struct NotView {
+  int first;
+  int second;
+};
+
+int main() {
+    static_assert(!boost::pfr::is_view_v<NotView>, "");
+    //static_assert(boost::pfr::is_view_v<View>, "");
+}
+


### PR DESCRIPTION
Needs to be used in [boost::fusion::traits::is_view](https://www.boost.org/doc/libs/master/libs/fusion/doc/html/fusion/support/is_view.html)'s implementation. I suppose it should be in the PFR for more extensibility.