### PR TITLE
Use relative URL for redirect in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=https://www.boost.org/doc/libs/master/doc/html/boost_pfr.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/boost_pfr.html">
 <title>Boost.Stacktrace</title>
 <style>
   body {
@@ -26,7 +26,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="https://www.boost.org/doc/libs/master/doc/html/boost_pfr.html">https://www.boost.org/doc/libs/master/doc/html/boost_pfr.html</a>
+    <a href="../../doc/html/boost_pfr.html">../../doc/html/boost_pfr.html</a>
   </p>
   <p>
     &copy; 2014-2023 Antony Polukhin


### PR DESCRIPTION
Makes redirect in index.html consistent with other boost libraries. This also works when browsing HTML files locally (release archive).