### PR TITLE
Couple of fixes for get_name

### DIFF
--- a/include/boost/pfr/detail/core_name20_static.hpp
+++ b/include/boost/pfr/detail/core_name20_static.hpp
@@ -207,6 +207,10 @@ constexpr std::string_view get_name() noexcept {
         "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
     );
     static_assert(
+        !std::is_array<T>::value,
+        "====================> Boost.PFR: It is impossible to extract name from old C array since it doesn't have named members"
+    );
+    static_assert(
         sizeof(T) && BOOST_PFR_USE_CPP17,
         "====================> Boost.PFR: Extraction of field's names is allowed only when the BOOST_PFR_USE_CPP17 macro enabled."
    );
@@ -219,6 +223,10 @@ constexpr auto tie_as_names_tuple() noexcept {
     static_assert(
         !std::is_union<T>::value,
         "====================> Boost.PFR: For safety reasons it is forbidden to reflect unions. See `Reflection of unions` section in the docs for more info."
+    );
+    static_assert(
+        !std::is_array<T>::value,
+        "====================> Boost.PFR: It is impossible to extract name from old C array since it doesn't have named members"
     );
     static_assert(
         sizeof(T) && BOOST_PFR_USE_CPP17,

--- a/test/config/print_config.cpp
+++ b/test/config/print_config.cpp
@@ -3,7 +3,10 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <boost/pfr/config.hpp> // inclusion of an another PFR header may fail when BOOST_PFR_ENABLED=0
+#include <boost/pfr/config.hpp>
+#if BOOST_PFR_ENABLED
+#include <boost/pfr.hpp>
+#endif
 #include <boost/preprocessor/stringize.hpp>
 
 #include <iostream>

--- a/test/core_name/compile-fail/fields_names_get_name_on_array.cpp
+++ b/test/core_name/compile-fail/fields_names_get_name_on_array.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#include <boost/pfr/core_name.hpp>
+
+int main() {
+    (void)boost::pfr::get_name<0, int[10]>(); // Must be a compile time error
+}
+
+

--- a/test/core_name/compile-fail/fields_names_names_as_array_on_array.cpp
+++ b/test/core_name/compile-fail/fields_names_names_as_array_on_array.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2023 Bela Schaum, X-Ryl669, Denis Mikhailov.
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Initial implementation by Bela Schaum, https://github.com/schaumb
+// The way to make it union and UB free by X-Ryl669, https://github.com/X-Ryl669
+//
+
+#include <boost/pfr/core_name.hpp>
+
+int main() {
+    (void)boost::pfr::names_as_array<int[10]>(); // Must be a compile time error
+}
+
+


### PR DESCRIPTION
1. Fixed printing of `BOOST_PFR_FUNCTION_SIGNATURE` in print_config.cpp
2. Fixed producing a trash from the call `boost::pfr::get_name<0, int[10]>()`