### PR TITLE
Micro-optimize PFR fields detection

### DIFF
--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -213,8 +213,8 @@ using one_element_range = std::true_type;
 template <class T>
 constexpr std::size_t fields_count_upper_bound_loose() noexcept {
 #if defined(_MSC_VER) && (_MSC_VER <= 1920)
-    if (sizeof(T) * CHAR_BIT > 1024) {
-        return 1024;
+    if (sizeof(T) * CHAR_BIT > 1000) {
+        return 1000;
     }
 #endif
 

--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -241,15 +241,15 @@ constexpr std::size_t fields_count_binary_search(detail::multi_element_range, in
 
 template <class T, std::size_t Begin, std::size_t Last>
 constexpr auto fields_count_binary_search(detail::multi_element_range, long) noexcept
-    -> detail::enable_if_initializable_helper_t<T, (Begin + Last) / 2 + 1>
+    -> detail::enable_if_initializable_helper_t<T, (Begin + Last + 1) / 2>
 {
-    constexpr std::size_t next_v = (Begin + Last) / 2 + 1;
+    constexpr std::size_t next_v = (Begin + Last + 1) / 2;
     return detail::fields_count_binary_search<T, next_v, Last>(detail::is_one_element_range<next_v, Last>{}, 1L);
 }
 
 template <class T, std::size_t Begin, std::size_t Last>
 constexpr std::size_t fields_count_binary_search(detail::multi_element_range, int) noexcept {
-    constexpr std::size_t next_v = (Begin + Last) / 2;
+    constexpr std::size_t next_v = (Begin + Last + 1) / 2 - 1;
     return detail::fields_count_binary_search<T, Begin, next_v>(detail::is_one_element_range<Begin, next_v>{}, 1L);
 }
 

--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -227,29 +227,29 @@ constexpr std::size_t fields_count_upper_bound_loose() noexcept {
 
 ///////////////////// Fields count binary search.
 // Template instantiation: depth is O(log(result)), count is O(log(result)), cost is O(result * log(result)).
-template <class T, std::size_t Begin, std::size_t Middle>
+template <class T, std::size_t Begin, std::size_t Last>
 constexpr std::size_t fields_count_binary_search(detail::one_element_range, long) noexcept {
     static_assert(
-        Begin == Middle,
+        Begin == Last,
         "====================> Boost.PFR: Internal logic error."
     );
     return Begin;
 }
 
-template <class T, std::size_t Begin, std::size_t Middle>
+template <class T, std::size_t Begin, std::size_t Last>
 constexpr std::size_t fields_count_binary_search(detail::multi_element_range, int) noexcept;
 
-template <class T, std::size_t Begin, std::size_t Middle>
+template <class T, std::size_t Begin, std::size_t Last>
 constexpr auto fields_count_binary_search(detail::multi_element_range, long) noexcept
-    -> detail::enable_if_initializable_helper_t<T, Middle>
+    -> detail::enable_if_initializable_helper_t<T, (Begin + Last) / 2 + 1>
 {
-    constexpr std::size_t next_v = Middle + (Middle - Begin + 1) / 2;
-    return detail::fields_count_binary_search<T, Middle, next_v>(detail::is_one_element_range<Middle, next_v>{}, 1L);
+    constexpr std::size_t next_v = (Begin + Last) / 2 + 1;
+    return detail::fields_count_binary_search<T, next_v, Last>(detail::is_one_element_range<next_v, Last>{}, 1L);
 }
 
-template <class T, std::size_t Begin, std::size_t Middle>
+template <class T, std::size_t Begin, std::size_t Last>
 constexpr std::size_t fields_count_binary_search(detail::multi_element_range, int) noexcept {
-    constexpr std::size_t next_v = Begin + (Middle - Begin) / 2;
+    constexpr std::size_t next_v = (Begin + Last) / 2;
     return detail::fields_count_binary_search<T, Begin, next_v>(detail::is_one_element_range<Begin, next_v>{}, 1L);
 }
 
@@ -349,8 +349,7 @@ constexpr auto fields_count_dispatch(long, int, std::true_type /*are_preconditio
 {
     constexpr std::size_t typical_fields_count = 4;
     constexpr std::size_t last = detail::fields_count_upper_bound<T, typical_fields_count / 2, typical_fields_count>(1L, 1L);
-    constexpr std::size_t middle = (last + 1) / 2;
-    return detail::fields_count_binary_search<T, 0, middle>(detail::is_one_element_range<0, middle>{}, 1L);
+    return detail::fields_count_binary_search<T, 0, last>(detail::is_one_element_range<0, last>{}, 1L);
 }
 
 template <class T>
@@ -360,8 +359,7 @@ constexpr std::size_t fields_count_dispatch(int, int, std::true_type /*are_preco
     constexpr std::size_t begin = detail::fields_count_lower_bound_unbounded<T, 1>(1L, size_t_<0>{});
 
     constexpr std::size_t last = detail::fields_count_upper_bound<T, begin, begin + 1>(1L, 1L);
-    constexpr std::size_t middle = (begin + last + 1) / 2;
-    return detail::fields_count_binary_search<T, begin, middle>(detail::is_one_element_range<begin, middle>{}, 1L);
+    return detail::fields_count_binary_search<T, begin, last>(detail::is_one_element_range<begin, last>{}, 1L);
 }
 
 ///////////////////// Returns fields count

--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -213,8 +213,9 @@ using one_element_range = std::true_type;
 template <class T>
 constexpr std::size_t fields_count_upper_bound_loose() noexcept {
 #if defined(_MSC_VER) && (_MSC_VER <= 1920)
-    if (sizeof(T) * CHAR_BIT > 1024)
+    if (sizeof(T) * CHAR_BIT > 1024) {
         return 1024;
+    }
 #endif
 
     return sizeof(T) * CHAR_BIT;
@@ -326,19 +327,19 @@ constexpr std::size_t fields_count_lower_bound_unbounded(int, size_t_<0>) noexce
 
 ///////////////////// Choosing between array size, unbounded binary search, and linear search followed by unbounded binary search.
 template <class T>
-constexpr auto fields_count_dispatch(long, long, std::integral_constant<bool, false>) noexcept {
+constexpr auto fields_count_dispatch(long, long, std::integral_constant<bool, false> /*are_preconditions_met*/) noexcept {
     return 0;
 }
 
 template <class T>
-constexpr auto fields_count_dispatch(long, long, std::integral_constant<bool, true>) noexcept
+constexpr auto fields_count_dispatch(long, long, std::integral_constant<bool, true> /*are_preconditions_met*/) noexcept
     -> typename std::enable_if<std::is_array<T>::value, std::size_t>::type
 {
     return sizeof(T) / sizeof(typename std::remove_all_extents<T>::type);
 }
 
 template <class T>
-constexpr auto fields_count_dispatch(long, int, std::integral_constant<bool, true>) noexcept
+constexpr auto fields_count_dispatch(long, int, std::integral_constant<bool, true> /*are_preconditions_met*/) noexcept
     -> decltype(sizeof(T{}))
 {
     constexpr std::size_t typical_fields_count = 4;
@@ -348,7 +349,7 @@ constexpr auto fields_count_dispatch(long, int, std::integral_constant<bool, tru
 }
 
 template <class T>
-constexpr std::size_t fields_count_dispatch(int, int, std::integral_constant<bool, true>) noexcept {
+constexpr std::size_t fields_count_dispatch(int, int, std::integral_constant<bool, true> /*are_preconditions_met*/) noexcept {
     // T is not default aggregate initializable. This means that at least one of the members is not default-constructible.
     // Use linear search to find the smallest valid initializer, after which we unbounded binary search for the largest.
     constexpr std::size_t begin = detail::fields_count_lower_bound_unbounded<T, 1>(1L, size_t_<0>{});

--- a/test/core/compile-fail/constructible_1_or_more_args.cpp
+++ b/test/core/compile-fail/constructible_1_or_more_args.cpp
@@ -5,7 +5,6 @@
 
 #include <boost/pfr/tuple_size.hpp>
 
-
 struct A {
     template <typename Arg0, typename... Args>
     explicit A(Arg0&&, Args&&...) {}

--- a/test/core/compile-fail/constructible_1_or_more_args.cpp
+++ b/test/core/compile-fail/constructible_1_or_more_args.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/pfr/tuple_size.hpp>
 
+
 struct A {
     template <typename Arg0, typename... Args>
     explicit A(Arg0&&, Args&&...) {}


### PR DESCRIPTION
* Start upper bound fields search from `4` fields, to avoid slow startup on typical workloads
* Inline the `fields_count_binary_search_unbounded` function to reduce template instantiations depth by 1
* Renamed `min` to `min_of_size_t` to avoid weired syntax
* Applied idea of better error reporting from #120
* Do not start fields count computation if one of the static asserts failed. That speedups error reporting in edge cases
* Use `std::*_t` versions of traits as they are faster in some implementations
* Rewrite binary search to simplify it and to avoid degradation to linear search on types that have constructor from variadic pack
* Remove default template parameters to simplify code

As a result, the whole test suite now runs 10%-25% faster on MSVC, ~20% faster on Clang, and 7%-20% faster on GCC.