### PR TITLE
Backport fix from PR #120 to tag 'boost-1.86.0'

### DIFF
--- a/include/boost/pfr/detail/fields_count.hpp
+++ b/include/boost/pfr/detail/fields_count.hpp
@@ -12,9 +12,14 @@
 #include <boost/pfr/detail/size_t_.hpp>
 #include <boost/pfr/detail/unsafe_declval.hpp>
 
+#ifdef BOOST_PFR_HAS_STD_MODULE
+import std;
+#else
 #include <climits>      // CHAR_BIT
+#include <cstdint>      // SIZE_MAX
 #include <type_traits>
 #include <utility>      // metaprogramming stuff
+#endif
 
 #ifdef __clang__
 #   pragma clang diagnostic push
@@ -25,6 +30,12 @@
 #endif
 
 namespace boost { namespace pfr { namespace detail {
+
+///////////////////// min without including <algorithm>
+template <class T>
+constexpr const T& (min)(const T& a, const T& b) {
+    return b < a ? b : a;
+}
 
 ///////////////////// Structure that can be converted to reference to anything
 struct ubiq_lref_constructor {
@@ -46,6 +57,14 @@ struct ubiq_rref_constructor {
     }
 };
 
+///////////////////// Hand-made is_complete<T> trait
+template <typename T, typename = void>
+struct is_complete : std::integral_constant<bool, false>
+{};
+
+template <typename T>
+struct is_complete<T, decltype(void(sizeof(T)))> : std::integral_constant<bool, true>
+{};
 
 #ifndef __cpp_lib_is_aggregate
 ///////////////////// Hand-made is_aggregate_initializable_n<T> trait
@@ -74,8 +93,16 @@ template <class T> struct is_single_field_and_aggregate_initializable<1, T>: std
 // Before C++20 aggregates could be constructed from `decltype(ubiq_?ref_constructor{I})...` but type traits report that
 // there's no constructor from `decltype(ubiq_?ref_constructor{I})...`
 // Special case for N == 1: `std::is_constructible<T, ubiq_?ref_constructor>` returns true if N == 1 and T is copy/move constructible.
-template <class T, std::size_t N>
+template <class T, std::size_t N, class /*Enable*/ = void>
 struct is_aggregate_initializable_n {
+    static constexpr bool value =
+           std::is_empty<T>::value
+        || std::is_array<T>::value
+    ;
+};
+
+template <class T, std::size_t N>
+struct is_aggregate_initializable_n<T, N, typename std::enable_if<std::is_class<T>::value && !std::is_empty<T>::value>::type> {
     template <std::size_t ...I>
     static constexpr bool is_not_constructible_n(std::index_sequence<I...>) noexcept {
         return (!std::is_constructible<T, decltype(ubiq_lref_constructor{I})...>::value && !std::is_constructible<T, decltype(ubiq_rref_constructor{I})...>::value)
@@ -83,12 +110,7 @@ struct is_aggregate_initializable_n {
         ;
     }
 
-    static constexpr bool value =
-           std::is_empty<T>::value
-        || std::is_array<T>::value
-        || std::is_fundamental<T>::value
-        || is_not_constructible_n(detail::make_index_sequence<N>{})
-    ;
+    static constexpr bool value = is_not_constructible_n(detail::make_index_sequence<N>{});
 };
 
 #endif // #ifndef __cpp_lib_is_aggregate
@@ -147,17 +169,40 @@ constexpr void* assert_first_not_base(std::index_sequence<>) noexcept
     return nullptr;
 }
 
-///////////////////// Helper for SFINAE on fields count
+template <class T, std::size_t N>
+constexpr void assert_first_not_base(int) noexcept {}
+
+template <class T, std::size_t N>
+constexpr auto assert_first_not_base(long) noexcept
+    -> typename std::enable_if<std::is_class<T>::value>::type
+{
+    detail::assert_first_not_base<T>(detail::make_index_sequence<N>{});
+}
+
+///////////////////// Helpers for initializable detection
+// Note that these take O(N) compile time and memory!
 template <class T, std::size_t... I, class /*Enable*/ = typename std::enable_if<std::is_copy_constructible<T>::value>::type>
-constexpr auto enable_if_constructible_helper(std::index_sequence<I...>) noexcept
-    -> typename std::add_pointer<decltype(T{ ubiq_lref_constructor{I}... })>::type;
+constexpr auto enable_if_initializable_helper(std::index_sequence<I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ubiq_lref_constructor{I}...})>::type;
 
 template <class T, std::size_t... I, class /*Enable*/ = typename std::enable_if<!std::is_copy_constructible<T>::value>::type>
-constexpr auto enable_if_constructible_helper(std::index_sequence<I...>) noexcept
-    -> typename std::add_pointer<decltype(T{ ubiq_rref_constructor{I}... })>::type;
+constexpr auto enable_if_initializable_helper(std::index_sequence<I...>) noexcept
+    -> typename std::add_pointer<decltype(T{ubiq_rref_constructor{I}...})>::type;
 
-template <class T, std::size_t N, class /*Enable*/ = decltype( enable_if_constructible_helper<T>(detail::make_index_sequence<N>()) ) >
-using enable_if_constructible_helper_t = std::size_t;
+template <class T, std::size_t N, class U = std::size_t, class /*Enable*/ = decltype(detail::enable_if_initializable_helper<T>(detail::make_index_sequence<N>()))>
+using enable_if_initializable_helper_t = U;
+
+template <class T, std::size_t N>
+constexpr auto is_initializable(long) noexcept
+    -> detail::enable_if_initializable_helper_t<T, N, bool>
+{
+    return true;
+}
+
+template <class T, std::size_t N>
+constexpr bool is_initializable(int) noexcept {
+    return false;
+}
 
 ///////////////////// Helpers for range size detection
 template <std::size_t Begin, std::size_t Last>
@@ -166,9 +211,26 @@ using is_one_element_range = std::integral_constant<bool, Begin == Last>;
 using multi_element_range = std::false_type;
 using one_element_range = std::true_type;
 
-///////////////////// Non greedy fields count search. Templates instantiation depth is log(sizeof(T)), templates instantiation count is log(sizeof(T)).
+
+///////////////////// Fields count next expected compiler limitation
+constexpr std::size_t fields_count_compiler_limitation_next(std::size_t n) noexcept {
+#if defined(_MSC_VER) && (_MSC_VER <= 1920)
+    if (n < 1024)
+        return 1024;
+#endif
+    return SIZE_MAX;
+}
+
+///////////////////// Fields count upper bound based on sizeof(T)
+template <class T>
+constexpr std::size_t fields_count_upper_bound_loose() noexcept {
+    return sizeof(T) * CHAR_BIT;
+}
+
+///////////////////// Fields count binary search.
+// Template instantiation: depth is O(log(result)), count is O(log(result)), cost is O(result * log(result)).
 template <class T, std::size_t Begin, std::size_t Middle>
-constexpr std::size_t detect_fields_count(detail::one_element_range, long) noexcept {
+constexpr std::size_t fields_count_binary_search(detail::one_element_range, long) noexcept {
     static_assert(
         Begin == Middle,
         "====================> Boost.PFR: Internal logic error."
@@ -177,87 +239,138 @@ constexpr std::size_t detect_fields_count(detail::one_element_range, long) noexc
 }
 
 template <class T, std::size_t Begin, std::size_t Middle>
-constexpr std::size_t detect_fields_count(detail::multi_element_range, int) noexcept;
+constexpr std::size_t fields_count_binary_search(detail::multi_element_range, int) noexcept;
 
 template <class T, std::size_t Begin, std::size_t Middle>
-constexpr auto detect_fields_count(detail::multi_element_range, long) noexcept
-    -> detail::enable_if_constructible_helper_t<T, Middle>
+constexpr auto fields_count_binary_search(detail::multi_element_range, long) noexcept
+    -> detail::enable_if_initializable_helper_t<T, Middle>
 {
     constexpr std::size_t next_v = Middle + (Middle - Begin + 1) / 2;
-    return detail::detect_fields_count<T, Middle, next_v>(detail::is_one_element_range<Middle, next_v>{}, 1L);
+    return detail::fields_count_binary_search<T, Middle, next_v>(detail::is_one_element_range<Middle, next_v>{}, 1L);
 }
 
 template <class T, std::size_t Begin, std::size_t Middle>
-constexpr std::size_t detect_fields_count(detail::multi_element_range, int) noexcept {
+constexpr std::size_t fields_count_binary_search(detail::multi_element_range, int) noexcept {
     constexpr std::size_t next_v = Begin + (Middle - Begin) / 2;
-    return detail::detect_fields_count<T, Begin, next_v>(detail::is_one_element_range<Begin, next_v>{}, 1L);
+    return detail::fields_count_binary_search<T, Begin, next_v>(detail::is_one_element_range<Begin, next_v>{}, 1L);
 }
 
-///////////////////// Greedy search. Templates instantiation depth is log(sizeof(T)), templates instantiation count is log(sizeof(T))*T in worst case.
-template <class T, std::size_t N>
-constexpr auto detect_fields_count_greedy_remember(long) noexcept
-    -> detail::enable_if_constructible_helper_t<T, N>
+template <class T, std::size_t Begin, std::size_t N>
+constexpr std::size_t fields_count_upper_bound(int, int) noexcept {
+    return N - 1;
+}
+
+template <class T, std::size_t Begin, std::size_t N>
+constexpr auto fields_count_upper_bound(long, long) noexcept
+    -> std::enable_if_t<(N > detail::fields_count_upper_bound_loose<T>()), std::size_t>
 {
-    return N;
+    static_assert(
+        !detail::is_initializable<T, detail::fields_count_upper_bound_loose<T>() + 1>(1L),
+        "====================> Boost.PFR: Types with user specified constructors (non-aggregate initializable types) are not supported.");
+    return detail::fields_count_upper_bound_loose<T>();
 }
 
-template <class T, std::size_t N>
-constexpr std::size_t detect_fields_count_greedy_remember(int) noexcept {
-    return 0;
+template <class T, std::size_t Begin, std::size_t N>
+constexpr auto fields_count_upper_bound(long, int) noexcept
+    -> detail::enable_if_initializable_helper_t<T, N>
+{
+    constexpr std::size_t next_optimal = Begin + (N - Begin) * 2;
+    constexpr std::size_t next = (detail::min)(next_optimal, detail::fields_count_compiler_limitation_next(N));
+    return detail::fields_count_upper_bound<T, Begin, next>(1L, 1L);
+}
+
+template <class T, std::size_t Begin = 0>
+constexpr std::size_t fields_count_binary_search_unbounded() noexcept {
+    constexpr std::size_t last = detail::fields_count_upper_bound<T, Begin, Begin + 1>(1L, 1L);
+    constexpr std::size_t middle = (Begin + last + 1) / 2;
+    return detail::fields_count_binary_search<T, Begin, middle>(detail::is_one_element_range<Begin, middle>{}, 1L);
+}
+
+///////////////////// Fields count lower bound linear search.
+// Template instantiation: depth is O(log(result)), count is O(result), cost is O(result^2).
+template <class T, std::size_t Begin, std::size_t Last, class RangeSize, std::size_t Result>
+constexpr std::size_t fields_count_lower_bound(RangeSize, size_t_<Result>) noexcept {
+    return Result;
 }
 
 template <class T, std::size_t Begin, std::size_t Last>
-constexpr std::size_t detect_fields_count_greedy(detail::one_element_range) noexcept {
+constexpr std::size_t fields_count_lower_bound(detail::one_element_range, size_t_<0> = {}) noexcept {
     static_assert(
         Begin == Last,
         "====================> Boost.PFR: Internal logic error."
     );
-    return detail::detect_fields_count_greedy_remember<T, Begin>(1L);
+    return detail::is_initializable<T, Begin>(1L) ? Begin : 0;
 }
 
 template <class T, std::size_t Begin, std::size_t Last>
-constexpr std::size_t detect_fields_count_greedy(detail::multi_element_range) noexcept {
+constexpr std::size_t fields_count_lower_bound(detail::multi_element_range, size_t_<0> = {}) noexcept {
+    // Binary partition to limit template depth.
     constexpr std::size_t middle = Begin + (Last - Begin) / 2;
-    constexpr std::size_t fields_count_big_range = detail::detect_fields_count_greedy<T, middle + 1, Last>(
-        detail::is_one_element_range<middle + 1, Last>{}
+    constexpr std::size_t result_maybe = detail::fields_count_lower_bound<T, Begin, middle>(
+        detail::is_one_element_range<Begin, middle>{}
     );
-
-    constexpr std::size_t small_range_begin = (fields_count_big_range ? 0 : Begin);
-    constexpr std::size_t small_range_last = (fields_count_big_range ? 0 : middle);
-    constexpr std::size_t fields_count_small_range = detail::detect_fields_count_greedy<T, small_range_begin, small_range_last>(
-        detail::is_one_element_range<small_range_begin, small_range_last>{}
+    return detail::fields_count_lower_bound<T, middle + 1, Last>(
+        detail::is_one_element_range<middle + 1, Last>{},
+        size_t_<result_maybe>{}
     );
-    return fields_count_big_range ? fields_count_big_range : fields_count_small_range;
 }
 
-///////////////////// Choosing between array size, greedy and non greedy search.
-template <class T, std::size_t N>
-constexpr auto detect_fields_count_dispatch(size_t_<N>, long, long) noexcept
+template <class T, std::size_t Begin = 1, std::size_t Result>
+constexpr std::size_t fields_count_lower_bound_unbounded(int, size_t_<Result>) noexcept {
+    return Result;
+}
+
+template <class T, std::size_t Begin = 1>
+constexpr auto fields_count_lower_bound_unbounded(long, size_t_<0> = {}) noexcept
+    -> std::enable_if_t<(Begin >= detail::fields_count_upper_bound_loose<T>()), std::size_t>
+{
+    static_assert(
+        detail::is_initializable<T, detail::fields_count_upper_bound_loose<T>()>(1L),
+        "====================> Boost.PFR: Type must be aggregate initializable.");
+    return detail::fields_count_upper_bound_loose<T>();
+}
+
+template <class T, std::size_t Begin = 1>
+constexpr std::size_t fields_count_lower_bound_unbounded(int, size_t_<0> = {}) noexcept {
+    constexpr std::size_t last = (detail::min)(Begin * 2, detail::fields_count_upper_bound_loose<T>()) - 1;
+    constexpr std::size_t result_maybe = detail::fields_count_lower_bound<T, Begin, last>(
+        detail::is_one_element_range<Begin, last>{}
+    );
+    return detail::fields_count_lower_bound_unbounded<T, last + 1>(1L, size_t_<result_maybe>{});
+}
+
+///////////////////// Choosing between array size, unbounded binary search, and linear search followed by unbounded binary search.
+template <class T>
+constexpr auto fields_count_dispatch(long, long) noexcept
     -> typename std::enable_if<std::is_array<T>::value, std::size_t>::type
 {
     return sizeof(T) / sizeof(typename std::remove_all_extents<T>::type);
 }
 
-template <class T, std::size_t N>
-constexpr auto detect_fields_count_dispatch(size_t_<N>, long, int) noexcept
+template <class T>
+constexpr auto fields_count_dispatch(long, int) noexcept
     -> decltype(sizeof(T{}))
 {
-    constexpr std::size_t middle = N / 2 + 1;
-    return detail::detect_fields_count<T, 0, middle>(detail::multi_element_range{}, 1L);
+    return detail::fields_count_binary_search_unbounded<T>();
 }
 
-template <class T, std::size_t N>
-constexpr std::size_t detect_fields_count_dispatch(size_t_<N>, int, int) noexcept {
-    // T is not default aggregate initialzable. It means that at least one of the members is not default constructible,
-    // so we have to check all the aggregate initializations for T up to N parameters and return the bigest succeeded
-    // (we can not use binary search for detecting fields count).
-    return detail::detect_fields_count_greedy<T, 0, N>(detail::multi_element_range{});
+template <class T>
+constexpr std::size_t fields_count_dispatch(int, int) noexcept {
+    // T is not default aggregate initializable. This means that at least one of the members is not default-constructible.
+    // Use linear search to find the smallest valid initializer, after which we unbounded binary search for the largest.
+    constexpr std::size_t begin = detail::fields_count_lower_bound_unbounded<T>(1L);
+    return detail::fields_count_binary_search_unbounded<T, begin>();
 }
 
 ///////////////////// Returns fields count
 template <class T>
 constexpr std::size_t fields_count() noexcept {
     using type = std::remove_cv_t<T>;
+
+    static_assert(
+        detail::is_complete<type>::value,
+        "====================> Boost.PFR: Type must be complete."
+    );
 
     static_assert(
         !std::is_reference<type>::value,
@@ -295,20 +408,14 @@ constexpr std::size_t fields_count() noexcept {
 //    );
 //#endif
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1920)
-    // Workaround for msvc compilers. Versions <= 1920 have a limit of max 1024 elements in template parameter pack
-    constexpr std::size_t max_fields_count = (sizeof(type) * CHAR_BIT >= 1024 ? 1024 : sizeof(type) * CHAR_BIT);
-#else
-    constexpr std::size_t max_fields_count = (sizeof(type) * CHAR_BIT); // We multiply by CHAR_BIT because the type may have bitfields in T
-#endif
+    constexpr std::size_t result = detail::fields_count_dispatch<type>(1L, 1L);
 
-    constexpr std::size_t result = detail::detect_fields_count_dispatch<type>(size_t_<max_fields_count>{}, 1L, 1L);
-
-    detail::assert_first_not_base<type>(detail::make_index_sequence<result>{});
+    detail::assert_first_not_base<type, result>(1L);
 
 #ifndef __cpp_lib_is_aggregate
     static_assert(
-        is_aggregate_initializable_n<type, result>::value,
+        detail::is_aggregate_initializable_n<type, result>::value  // Does not return `true` for built-in types.
+        || std::is_scalar<type>::value,
         "====================> Boost.PFR: Types with user specified constructors (non-aggregate initializable types) are not supported."
     );
 #endif


### PR DESCRIPTION
# Description

- It applies PR #120 on top of `boost-pfr-1.86.0`.