### PR TITLE
Update interface library properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,17 @@ if (BOOST_USE_MODULES)
     target_include_directories(boost_pfr PUBLIC include)
 else()
     add_library(boost_pfr INTERFACE)
-    target_include_directories(boost_pfr INTERFACE include)
+
+    if (CMAKE_VERSION VERSION_LESS "3.23.0")
+        target_include_directories(boost_pfr INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                       $<INSTALL_INTERFACE:include>)
+    else()
+        file(GLOB_RECURSE PFR_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
+        target_sources(boost_pfr INTERFACE
+            FILE_SET HEADERS TYPE HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
+                                          FILES ${PFR_HEADERS}
+        )
+    endif()
 endif()
 
 add_library(Boost::pfr ALIAS boost_pfr)
@@ -45,4 +55,3 @@ if (BOOST_USE_MODULES AND BUILD_TESTING)
     target_link_libraries(boost_pfr_module_usage_mu PRIVATE Boost::pfr)
     add_test(NAME boost_pfr_module_usage_mu COMMAND boost_pfr_module_usage_mu)
 endif()
-


### PR DESCRIPTION
Implement solution to problem from #217 

I used a glob as I usually do to keep the file list concise, but I don't know if it's the proper boost etiquette.
The target_sources allow for wetter handling of the headers during install, but I also fixed the issue with the absolute path when using CMake version where the target_sources command with file sets is not available.

You can test it with a sample project:
```text
 sample
 ├── include
 │   └── sample
 │       └── header.hpp
 ├── src
 │   └── main.cpp
 └── CMakeLists.txt
```

CMakeLists.txt:
```cmake
cmake_minimum_required(VERSION 3.28)

project(sample VERSION 1.0.0)

add_subdirectory(${PFR_DIR} pfr)

add_executable(exe)
target_sources(exe PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp)
target_link_libraries(exe Boost::pfr)

install(TARGETS exe EXPORT sampleTargets)

add_library(lib INTERFACE)
target_sources(lib INTERFACE FILE_SET HEADERS TYPE HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include/
                                                           FILES "include/sample/header.hpp")
target_link_libraries(lib INTERFACE Boost::pfr)

install(TARGETS lib EXPORT sampleTargets FILE_SET HEADERS)
install(TARGETS boost_pfr EXPORT sampleTargets FILE_SET HEADERS)

install(EXPORT sampleTargets
        FILE sampleTargets.cmake
        NAMESPACE sample::
        DESTINATION cmake/sample)

```
main.cpp:
```cpp
#include "boost/pfr.hpp"
#include <iostream>

struct A {
    int _i1{1};
    int _i2{2};
    int _i3{3};
    int _i4{4};
};

int main() {
    boost::pfr::for_each_field(A{}, [](auto &v){ std::cout << v << "\n"; });
    return 0;
}

```

header.hpp:
```cpp
#pragma once

#include "boost/pfr.hpp"

// ... Whatever it's just a sample header...
```
