### PR TITLE
fix ci: turn on import std tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - toolset: gcc-14  # Do not remove! It is the only toolset that tests CMake tests down below
             cxxstd: "03,11,14,17,20"
             os: ubuntu-24.04
+            compiler: g++-14
           - toolset: gcc-12
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
@@ -47,6 +48,7 @@ jobs:
           - toolset: clang-19   # tests misc/strip_boost_namespace.sh and modules
             cxxstd: "20,23"
             os: ubuntu-24.04
+            compiler: clang++-19
             install: clang-19 llvm-19 libclang-rt-19-dev libc++-19-dev libc++abi-19-dev clang-tools-19
 
     runs-on: ${{matrix.os}}
@@ -83,14 +85,13 @@ jobs:
           ./b2 variant=debug tools/inspect
 
       - name: Run CMake tests
-        if: ${{matrix.toolset == 'gcc-14'}}
+        if: ${{matrix.toolset == 'gcc-14' || matrix.toolset == 'clang-19'}}
         run: |
           cd ../boost-root/
           cmake -S . -B __build \
             -DBUILD_TESTING=1 \
             -DBOOST_INCLUDE_LIBRARIES=pfr \
-            -DCMAKE_CXX_COMPILER=g++-14 \
-            -DCMAKE_C_COMPILER=gcc-14
+            -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
           cmake --build __build --target tests
           ctest --test-dir __build --output-on-failure --no-tests=error
           rm -rf __build
@@ -116,12 +117,12 @@ jobs:
         if: ${{matrix.toolset == 'clang-19'}}
         run: |
           cd ../boost-root/libs/pfr
-          mkdir build_module
-          cd build_module
-          cmake -DBOOST_USE_MODULES=1 -DBUILD_TESTING=1 -GNinja -DCMAKE_CXX_COMPILER=clang++-19 ../test/cmake_subdir_test
-          cmake --build .
-          ctest -V
-          cd ..
+          cmake -S test/cmake_test_subdir -B build_module -GNinja \
+            -DBOOST_USE_MODULES=1
+            -DBUILD_TESTING=1
+            -DCMAKE_CXX_COMPILER=clang++-19
+          cmake --build build_module
+          ctest --test-dir build_module --no-tests=error -VV
           rm -rf build_module
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           cmake -S . -B __build \
             -DBUILD_TESTING=1 \
             -DBOOST_INCLUDE_LIBRARIES=pfr \
-            -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+            -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
           cmake --build __build --target tests
           ctest --test-dir __build --output-on-failure --no-tests=error
           rm -rf __build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,13 @@ jobs:
         if: ${{matrix.toolset == 'gcc-14'}}
         run: |
           cd ../boost-root/
-          mkdir __build
-          cd __build
-          cmake -DBUILD_TESTING=1 -DBOOST_INCLUDE_LIBRARIES=pfr -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14 ..
-          cmake --build . --target tests
-          ctest --output-on-failure --no-tests=error
-          cd ..
+          cmake -S . -B __build \
+            -DBUILD_TESTING=1 \
+            -DBOOST_INCLUDE_LIBRARIES=pfr \
+            -DCMAKE_CXX_COMPILER=g++-14 \
+            -DCMAKE_C_COMPILER=gcc-14
+          cmake --build __build --target tests
+          ctest --test-dir __build --output-on-failure --no-tests=error
           rm -rf __build
 
       - name: Run modules tests
@@ -108,7 +109,7 @@ jobs:
             -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=0e5b6991-d74f-4b3d-a41c-cf096e0b2508 \
             -DCMAKE_CXX_MODULE_STD=ON
           cmake --build build_module
-          ctest --test-dir build_module -VV
+          ctest --test-dir build_module --no-tests=error -VV
           rm -rf build_module
 
       - name: Run modules tests without 'import std;'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,9 @@ jobs:
         if: ${{matrix.toolset == 'clang-19'}}
         run: |
           cd ../boost-root/libs/pfr
-          cmake -S test/cmake_test_subdir -B build_module -GNinja \
-            -DBOOST_USE_MODULES=1
-            -DBUILD_TESTING=1
+          cmake -S test/cmake_subdir_test -B build_module -GNinja \
+            -DBOOST_USE_MODULES=1 \
+            -DBUILD_TESTING=1 \
             -DCMAKE_CXX_COMPILER=clang++-19
           cmake --build build_module
           ctest --test-dir build_module --no-tests=error -VV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,19 +95,23 @@ jobs:
           rm -rf __build
 
       - name: Run modules tests
-        if: false
-        # if: ${{matrix.toolset == 'clang-19'}}
+        if: ${{matrix.toolset == 'clang-19'}}
         run: |
           cd ../boost-root/libs/pfr
-          mkdir build_module
-          cd build_module
-          cmake -DBUILD_TESTING=1 -DBOOST_USE_MODULES=1 -DCMAKE_CXX_COMPILER=clang++-19 -DCMAKE_CXX_FLAGS=-stdlib=libc++ -DCMAKE_EXE_LINKER_FLAGS=-stdlib=libc++ -DCMAKE_CXX_STANDARD=23 -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=0e5b6991-d74f-4b3d-a41c-cf096e0b2508 -G Ninja ../test/cmake_subdir_test
-          cmake --build .
-          ctest -V
-          cd ..
+          cmake -S test/cmake_subdir_test -B build_module \
+            -GNinja \
+            -DBUILD_TESTING=1 \
+            -DBOOST_USE_MODULES=1 \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
+            -DCMAKE_CXX_FLAGS=-stdlib=libc++ \
+            -DCMAKE_CXX_STANDARD=23 \
+            -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=0e5b6991-d74f-4b3d-a41c-cf096e0b2508 \
+            -DCMAKE_CXX_MODULE_STD=ON
+          cmake --build build_module
+          ctest --test-dir build_module -VV
           rm -rf build_module
 
-      - name: Run modules tests wihtout 'import std;'
+      - name: Run modules tests without 'import std;'
         if: ${{matrix.toolset == 'clang-19'}}
         run: |
           cd ../boost-root/libs/pfr

--- a/include/boost/pfr/config.hpp
+++ b/include/boost/pfr/config.hpp
@@ -8,6 +8,8 @@
 #define BOOST_PFR_CONFIG_HPP
 #pragma once
 
+#include <compare>
+
 #if !defined(BOOST_USE_MODULES) && (__cplusplus >= 201402L || (defined(_MSC_VER) && defined(_MSVC_LANG) && _MSC_VER > 1900))
 #include <type_traits> // to get non standard platform macro definitions (__GLIBCXX__ for example)
 #endif

--- a/include/boost/pfr/config.hpp
+++ b/include/boost/pfr/config.hpp
@@ -8,7 +8,9 @@
 #define BOOST_PFR_CONFIG_HPP
 #pragma once
 
+#if defined(BOOST_USE_MODULES)
 #include <compare>
+#endif
 
 #if !defined(BOOST_USE_MODULES) && (__cplusplus >= 201402L || (defined(_MSC_VER) && defined(_MSVC_LANG) && _MSC_VER > 1900))
 #include <type_traits> // to get non standard platform macro definitions (__GLIBCXX__ for example)

--- a/modules/boost_pfr.cppm
+++ b/modules/boost_pfr.cppm
@@ -11,6 +11,7 @@ module;
 #include <version>
 #include <cstddef>
 #include <cstdint>
+#include <compare>
 
 #ifdef BOOST_PFR_USE_STD_MODULE
 import std;

--- a/modules/usage_sample.cpp
+++ b/modules/usage_sample.cpp
@@ -8,7 +8,6 @@
 
 //[pfr_module_example
 #include <iostream>
-#include <iomanip>
 #include <string>
 
 import boost.pfr;

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -17,4 +17,5 @@ add_subdirectory(../../../mp11 boostorg/mp11)
 add_subdirectory(../../../throw_exception boostorg/throw_exception)
 add_subdirectory(../../../type_traits boostorg/type_traits)
 
+enable_testing()
 add_subdirectory(../../ boostorg/pfr)


### PR DESCRIPTION
This PR enables tests with `import std` usage in CI