### PR TITLE
Do not treat std::array as implicitly reflectable (#169)

### DIFF
--- a/include/boost/pfr/detail/possible_reflectable.hpp
+++ b/include/boost/pfr/detail/possible_reflectable.hpp
@@ -11,10 +11,22 @@
 #include <boost/pfr/traits_fwd.hpp>
 
 #if !defined(BOOST_PFR_INTERFACE_UNIT)
+#include <array>       // for std::array
+#include <cstddef>     // for std::size_t
 #include <type_traits> // for std::is_aggregate
 #endif
 
 namespace boost { namespace pfr { namespace detail {
+
+// std::array<T, N> is an aggregate, but it stores its elements in a C array
+// data member. Boost.PFR can not reflect types with C array members yet (see
+// https://github.com/boostorg/pfr/issues/20), so std::array must not be
+// treated as implicitly reflectable.
+template <class T>
+struct is_stdarray : std::false_type {};
+
+template <class T, std::size_t N>
+struct is_stdarray<std::array<T, N>> : std::true_type {};
 
 ///////////////////// Returns false when the type exactly wasn't be reflectable
 template <class T, class WhatFor>
@@ -26,11 +38,11 @@ constexpr decltype(is_reflectable<T, WhatFor>::value) possible_reflectable(long)
 
 template <class T, class WhatFor>
 constexpr bool possible_reflectable(int) noexcept {
-#   if  defined(__cpp_lib_is_aggregate)
     using type = std::remove_cv_t<T>;
-    return std::is_aggregate<type>();
+#   if  defined(__cpp_lib_is_aggregate)
+    return std::is_aggregate<type>() && !detail::is_stdarray<type>::value;
 #   else
-    return true;
+    return !detail::is_stdarray<type>::value;
 #   endif
 }
 

--- a/test/core/run/is_implicitly_reflectable.cpp
+++ b/test/core/run/is_implicitly_reflectable.cpp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <array>
 #include <iostream>
 #include <boost/pfr/traits.hpp>
 #include <type_traits>  // for std::true_type, std::false_type and std::is_aggregate
@@ -71,6 +72,12 @@ int main() {
         assert_non_reflectable<Nonrefrectable, tag>();
         assert_reflectable<ReflectableBoostJson, tag>();
         assert_non_reflectable<NonrefrectableBoostJson, tag>();
+
+        // std::array is an aggregate, but it holds a C array member that
+        // Boost.PFR can not reflect correctly, so it must not be considered
+        // implicitly reflectable (https://github.com/boostorg/pfr/issues/169).
+        assert_non_reflectable<std::array<int, 3>, tag>();
+        assert_non_reflectable<std::array<char, 1>, tag>();
     }
 
     {
@@ -81,6 +88,10 @@ int main() {
         assert_non_reflectable<Nonrefrectable, tag>();
         assert_reflectable<ReflectableBoostFusion, tag>();
         assert_non_reflectable<NonrefrectableBoostFusion, tag>();
+
+        // See the comment in the boost_json_tag block above.
+        assert_non_reflectable<std::array<int, 3>, tag>();
+        assert_non_reflectable<std::array<char, 1>, tag>();
     }
 #endif  // #if BOOST_PFR_ENABLE_IMPLICIT_REFLECTION
 }


### PR DESCRIPTION
## Problem

`boost::pfr::is_implicitly_reflectable_v<std::array<T, N>>` evaluates to `true`
because `std::array` is an aggregate. But `std::array` keeps its elements in a
single C array data member, which Boost.PFR can not reflect correctly yet
(#20) — tuple size and per-field access are wrong. Since downstream adaptors
use `is_reflectable` / `is_implicitly_reflectable` to decide whether to route a
type through PFR, the trait reporting `true` makes them mis-handle `std::array`.

This is the explicit request in #169.

## Change

* Add a `detail::is_stdarray` trait.
* Exclude `std::array` from the implicit reflection branch in
  `detail/possible_reflectable.hpp`, both with and without
  `__cpp_lib_is_aggregate`.

The change only affects the `is_implicitly_reflectable` decision; ordinary
aggregates are unaffected, and no public API is added or removed.

## Tests

Extended `test/core/run/is_implicitly_reflectable.cpp` to assert that
`std::array` (and its cv-qualified forms) is non-reflectable for both the
`boost_json_tag` and `boost_fusion_tag` tags, while plain aggregates stay
reflectable.

Verified locally with g++ 15.2 at `cxxstd=14/17/20`; the existing
`is_reflectable`, `is_implicitly_reflectable`, and `tuple_size` run-tests
continue to pass.

Closes #169.