### PR TITLE
Use BASE_DIRS to install modules right

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,26 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.28...4.4)
 
 project(boost_pfr VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
-if (BOOST_USE_MODULES)
-    add_library(boost_pfr)
+if(BOOST_USE_MODULES)
+    add_library(boost_pfr STATIC)
     target_sources(boost_pfr PUBLIC
-        FILE_SET modules_public TYPE CXX_MODULES FILES modules/boost_pfr.cppm
+        FILE_SET CXX_MODULES
+            BASE_DIRS modules
+            FILES modules/boost_pfr.cppm
     )
 
     target_compile_features(boost_pfr PUBLIC cxx_std_20)
     target_compile_definitions(boost_pfr PUBLIC BOOST_USE_MODULES)
-    if (CMAKE_CXX_COMPILER_IMPORT_STD)
-        target_compile_definitions(boost_pfr PRIVATE BOOST_PFR_USE_STD_MODULE)
+    if(NOT CMAKE_CXX_STANDARD)
+        set(CMAKE_CXX_STANDARD 20)
+    endif()
+    if(CMAKE_CXX_MODULE_STD AND CMAKE_CXX_STANDARD IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD)
+        target_compile_definitions(boost_pfr PUBLIC BOOST_PFR_USE_STD_MODULE)
+        target_compile_features(boost_pfr PUBLIC cxx_std_23)
         message(STATUS "Using `import std;`")
     else()
         message(STATUS "`import std;` is not available")
@@ -31,11 +37,11 @@ endif()
 add_library(Boost::pfr ALIAS boost_pfr)
 
 enable_testing()
-if (BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
     add_subdirectory(test)
 endif()
 
-if (BOOST_USE_MODULES AND BUILD_TESTING)
+if(BOOST_USE_MODULES AND BUILD_TESTING)
     add_executable(boost_pfr_module_usage modules/usage_sample.cpp)
     target_link_libraries(boost_pfr_module_usage PRIVATE Boost::pfr)
     add_test(NAME boost_pfr_module_usage COMMAND boost_pfr_module_usage)

--- a/include/boost/pfr/detail/io.hpp
+++ b/include/boost/pfr/detail/io.hpp
@@ -51,6 +51,7 @@ template <std::size_t I, std::size_t N>
 struct print_impl {
     template <class Stream, class T>
     static void print (Stream& out, const T& value) {
+        using std::operator<<;
         if (!!I) out << ", ";
         out << detail::quoted_helper(boost::pfr::detail::sequence_tuple::get<I>(value));
         print_impl<I + 1, N>::print(out, value);
@@ -67,6 +68,7 @@ template <std::size_t I, std::size_t N>
 struct read_impl {
     template <class Stream, class T>
     static void read (Stream& in, const T& value) {
+        using std::operator>>;
         char ignore = {};
         if (!!I) {
             in >> ignore;


### PR DESCRIPTION
Merge the cmake logic and c++ version handling with other boost modules, i.e. any, type_index, lexical_cast, and conversion

Based on my work/tests at https://github.com/ClausKlein/boost-cmake/pull/13